### PR TITLE
also write file that tyche needs to differentiate between the same te…

### DIFF
--- a/CsCheck/Logging.cs
+++ b/CsCheck/Logging.cs
@@ -97,7 +97,8 @@ public static class Logging
                     {
                         var testcasesFilePath = Path.Combine(projectRoot, $".CsCheck\\observed", $"{todayString}_testcases.jsonl");
                         Directory.CreateDirectory(Path.GetDirectoryName(testcasesFilePath)!);
-                        using var w = new StreamWriter(testcasesFilePath, true);
+                        var fileStream = new FileStream(testcasesFilePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+                        using var w = new StreamWriter(fileStream);
                         w.AutoFlush = true;
                         await LogTycheTestCases(propertyUnderTest, w, channel, runStart).ConfigureAwait(false);
                     }

--- a/CsCheck/Logging.cs
+++ b/CsCheck/Logging.cs
@@ -48,9 +48,8 @@ public static class Logging
         Tyche,
     }
 
-    public static ILogger<T> CreateLogger<T>(StreamWriter w, LogProcessor p, string propertyUnderTest)
+    public static ILogger<T> CreateLogger<T>(LogProcessor p, string propertyUnderTest, StreamWriter? writer = null)
     {
-        w.AutoFlush = true;
         var channel = Channel.CreateUnbounded<(T Value, bool Success)>(
             new UnboundedChannelOptions
             {
@@ -63,23 +62,66 @@ public static class Logging
             case LogProcessor.Tyche:
                 var t = async () =>
                 {
-                    while (await channel.Reader.WaitToReadAsync().ConfigureAwait(false))
+                    var todayString = $"{DateTime.Today.Date:yyyy-M-dd}";
+                    var projectRoot = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"..\..\.."));
+
+                    var runStart = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
+                    if (writer == null)
                     {
-                        var d = new Dictionary<string, string>(StringComparer.Ordinal);
-                        var (value, success) = await channel.Reader.ReadAsync().ConfigureAwait(false);
-                        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
-                        var tycheData = new TycheData(
-                            "test_case", timestamp, propertyUnderTest,
-                            success ? "passed" : "failed", JsonSerializer.Serialize(value),
-                            "reason", d, "testing", d, null, d, d
-                        );
-                        var serializedData = JsonSerializer.Serialize(tycheData);
-                        await w.WriteLineAsync(serializedData).ConfigureAwait(false);
+                        var infoFilePath = Path.Combine(projectRoot, ".cscheck\\observed", $"{todayString}_info.jsonl");
+                        Directory.CreateDirectory(Path.GetDirectoryName(infoFilePath)!);
+
+                        //Log information that Tyche uses to distinguish between different runs
+                        using var infoWriter = new StreamWriter(infoFilePath, true);
+                        infoWriter.AutoFlush = true;
+
+                        var infoRecord =
+                            new
+                            {
+                                type = "info",
+                                run_start = runStart,
+                                property = propertyUnderTest,
+                                title = "Hypothesis Statistics",
+                                content = ""
+                            };
+                        await infoWriter.WriteLineAsync(JsonSerializer.Serialize(infoRecord)).ConfigureAwait(false);
+                        infoWriter.Close();
+                    }
+
+                    if (writer != null)
+                    {
+                        writer.AutoFlush = true;
+                        await LogTycheTestCases(propertyUnderTest, writer, channel, runStart).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        var testcasesFilePath = Path.Combine(projectRoot, $".CsCheck\\observed", $"{todayString}_testcases.jsonl");
+                        Directory.CreateDirectory(Path.GetDirectoryName(testcasesFilePath)!);
+                        using var w = new StreamWriter(testcasesFilePath, true);
+                        w.AutoFlush = true;
+                        await LogTycheTestCases(propertyUnderTest, w, channel, runStart).ConfigureAwait(false);
                     }
                 };
                 return new TycheLogger<T>(t, channel);
             default:
                 throw new ArgumentOutOfRangeException(nameof(p), p, null);
+        }
+    }
+
+    private static async Task LogTycheTestCases<T>(string propertyUnderTest, StreamWriter writer, Channel<(T Value, bool Success)> channel,
+        double runStart)
+    {
+        while (await channel.Reader.WaitToReadAsync().ConfigureAwait(false))
+        {
+            var d = new Dictionary<string, string>(StringComparer.Ordinal);
+            var (value, success) = await channel.Reader.ReadAsync().ConfigureAwait(false);
+            var tycheData = new TycheData(
+                "test_case", runStart, propertyUnderTest,
+                success ? "passed" : "failed", JsonSerializer.Serialize(value),
+                "reason", d, "testing", d, null, d, d
+            );
+            var serializedData = JsonSerializer.Serialize(tycheData);
+            await writer.WriteLineAsync(serializedData).ConfigureAwait(false);
         }
     }
 }

--- a/Tests/LoggingTests.cs
+++ b/Tests/LoggingTests.cs
@@ -19,7 +19,8 @@ public class LoggingTests
     {
         using var memoryStream = new MemoryStream();
         using var writer = new StreamWriter(memoryStream);
-        var logger = Logging.CreateLogger<int[]>(writer, Logging.LogProcessor.Tyche, "Bool_Distribution_WithTycheLogs");
+        writer.AutoFlush = true;
+        var logger = Logging.CreateLogger<int[]>(Logging.LogProcessor.Tyche, "Bool_Distribution_WithTycheLogs", writer);
 
         // Random test logic
         const int frequency = 10;
@@ -60,13 +61,11 @@ public class LoggingTests
     }
 
     //Test below can be used to see example of output
-    [Theory(Skip = "don't run test that generates output")]
+    [Theory(Skip="Only run if you want to verify Tyche output")]
     [InlineData(1)]
     public void Bool_Distribution_WithTycheLogs_ToFile(int generatedIntUponTrue)
     {
-        var projectRoot = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"..\..\.."));
-        using var writer = new StreamWriter(Path.Combine(projectRoot, "Logging", "Testrun.jsonl"));
-        var logger = Logging.CreateLogger<int[]>(writer, Logging.LogProcessor.Tyche, "Bool_Distribution_WithTycheLogs");
+        var logger = Logging.CreateLogger<int[]>(Logging.LogProcessor.Tyche, "Bool_Distribution_WithTycheLogs");
 
         // Random test logic
         const int frequency = 10;
@@ -77,7 +76,7 @@ public class LoggingTests
         {
             Gen.Bool.Select(i => i ? generatedIntUponTrue : 0).Array[2 * frequency]
                 .Select(sample => Tally(2, sample))
-                .Sample(actual => Check.ChiSquared(expected, actual, 10), iter: 100, time: -2, logger: logger);
+                .Sample(actual => Check.ChiSquared(expected, actual, 10), iter: 1, time: -2, logger: logger);
         }
         catch
         {


### PR DESCRIPTION
…st run at differnt times.

specify default directory name and files.

Name of file containing testcases is {date:yyyy-M-dd}_testcases.jsonl. So "2024-10-19_testcases.jsonl".
Name of file containing testinfo is {date:yyyy-M-dd}_testinfo.jsonl. So "2024-10-19_testinfo.jsonl".

Located in ".cscheck\observed\" directory, which is generated wherever the test is run.

I also verified that the test cases are generated in realtime by building the nuget package and copying the tests I write in a separate project.
