### PR TITLE
Clarify that `skipped` in a Sample failure message is not an error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,11 @@ usage pattern, find a similar test there first and follow it.
   `AnalysisMode All` with Meziantou.Analyzer). Keep generated code warning-clean.
 - **No reflection** is used in the library; prefer composing generators over
   reflection-based helpers.
-- A failing `Sample` shrinks to the simplest example and prints a **seed**
-  string. Re-run with `seed:` to reproduce exactly.
+- A failing `Sample` shrinks to the simplest example and prints a line with a
+  **seed** plus `(N shrinks, M skipped, K total)`. Re-run with `seed:` to
+  reproduce exactly. `skipped` counts shrink-phase candidates that weren't
+  smaller than the current minimal failure, so they were never asserted — it is
+  **not** errors or `Where`-filtered inputs, and is `0` in a passing run.
 
 ## Writing tests — the core entry points
 
@@ -177,3 +180,9 @@ Global defaults via environment variables: `CsCheck_Iter`, `CsCheck_Time`,
   versions — don't rely on it in committed library code.
 - Prefer `Gen.Const(() => new ...())` (factory) over a shared instance for
   parallel/model tests so each run gets a fresh state.
+- **`skipped` in a failure message is not a problem.** It counts shrink-phase
+  candidates whose generated `Size` was not smaller than the current smallest
+  failure, so they were skipped rather than asserted. It does **not** mean
+  inputs threw, were `Where`-filtered, or that coverage was lost. It only
+  becomes non-zero *after* a failure triggers shrinking; a passing test always
+  reports `0 skipped`. Do not treat a large `skipped` count as a secondary bug.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ static readonly Gen<JsonNode> genJsonNode = Gen.Recursive<JsonNode>((depth, genJ
 The default sample size is 100 iterations. Set iter: to change this or time: to run for a number of seconds.  
 Setting these from the command line can be a good way to run your tests in different ways and in Release mode.
 
+A failing **Sample** throws with a line like:
+
+```
+Set seed: "0000018ab..." or -e CsCheck_Seed=0000018ab... to reproduce (12 shrinks, 3,456 skipped, 4,000 total).
+```
+
+- **seed** - paste into `seed:` (or `CsCheck_Seed`) to replay this exact failure.
+- **shrinks** - how many progressively-smaller failing cases were found before the simplest one shown below.
+- **skipped** - shrink-phase candidates that were **not smaller** than the current minimal failure, so they were never asserted. This is expected, not an error: it is *not* a count of exceptions, filtered (`Where`) inputs, or lost coverage. It is `0` in any passing run and only appears once a failure has been found and shrinking begins. A large number just means the shrinker generated many non-smaller candidates while hunting for the simplest one.
+- **total** - total candidates generated (asserted + skipped).
+
 ### Unit Single
 ```csharp
 [Test]

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,7 @@
 Key facts an assistant should know before generating CsCheck code:
 
 - You compose a `Gen<T>` and call a terminating method (`Sample`, `SampleModelBased`, `SampleMetamorphic`, `SampleParallel`, `Faster`, `Check.Hash`). There are **no `Arb` classes** and you **never write shrinkers** — shrinking is automatic.
-- A failing test shrinks to the simplest case and prints a **seed**; re-run with `seed:` to reproduce.
+- A failing test shrinks to the simplest case and prints a **seed** plus `(N shrinks, M skipped, K total)`; re-run with `seed:` to reproduce. `skipped` = shrink-phase candidates that weren't smaller than the current minimal failure, so they were never asserted — **not** errors or `Where`-filtered inputs, and `0` in a passing run.
 - CsCheck is **test-framework agnostic**: it signals failure by throwing an exception (or `Sample` returning `false`), with no dependency on any test runner. Use it with xUnit, NUnit, MSTest, TUnit, or no framework at all. This repo's own tests happen to use TUnit + Microsoft.Testing.Platform, but that is not required.
 - The `Tests/` project is the canonical example collection.
 - Install: `dotnet add package CsCheck`. License: Apache-2.0.


### PR DESCRIPTION
The failure line prints `(N shrinks, M skipped, K total)`. `skipped` only counts shrink-phase candidates whose generated Size was not smaller than the current minimal failure, so they were never asserted. It is 0 in a passing run and is not a count of exceptions or Where-filtered inputs. Readers (including AI assistants) have misread it as discarded/errored inputs, so document its meaning in README.md, AGENTS.md and llms.txt.